### PR TITLE
Disaster recovery for tiamat

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A collection of scripts from [The Obscure Organization](https://www.obscure.org)
 * [ssh-add-ramdisk.sh](ssh-add-ramdisk.sh) - Keep your SSH keys on a USB key, but load them into a RAMDisk on macOS or Linux - so you don't have to keep permanent copies of the SSH keys on the systems you physically use, which is useful sometimes.
 * [ssh-env.sh](ssh-env.sh) - Use to help reconnect managed terminal sessions (think `screen` or `tmux`) terminals to your SSH key agent via environment manipulation.
 * [uptimerobot-firewall-update.sh](uptimerobot-firewall-update.sh) - Update firewall entries that allow [uptimerobot.com](https://www.uptimerobot.com/) to check otherwise resticted services. Uptime Robot is free and is suitable for small-scale monitoring as a primary service or as a secondary monitor that watches your primary monitoring system and most critical services.
+* [tiamat-setup.sh](tiamat-setup.sh) - Set up packages and more on tiamat.obscure.org (emergency recovery script)
 * [watch-filevault-setup.sh](wuhatch-filevault-setup.sh) - Watch and log the filevault encryption process, which can take a really long time on an older Macintosh.
 
 Acknowledgements

--- a/cert-notifier.sh
+++ b/cert-notifier.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# cert-notifier.sh
+# After renewing SSL certificates with Certbot we need to copy
+# them to the locations that Sendmail and Dovecot use, and then
+# restart those subsystems.
+# 
+# Configure this in /etc/sysconfig/certbot
+
+# Set unofficial bash strict mode http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -euo pipefail
+IFS=$'\n\t'
+
+DEBUG=${DEBUG:-false}
+
+# Thanks https://stackoverflow.com/a/17805088
+$DEBUG && export PS4='${LINENO}: ' && set -x
+
+cp /etc/letsencrypt/live/obscure.org/privkey.pem  /etc/pki/dovecot/private/dovecot.pem
+cp /etc/letsencrypt/live/obscure.org/fullchain.pem  /etc/pki/dovecot/certs/dovecot.pem
+cp /etc/letsencrypt/live/obscure.org/privkey.pem /etc/pki/tls/private/sendmail.key
+cp /etc/letsencrypt/live/obscure.org/fullchain.pem  /etc/pki/tls/certs/sendmail.pem
+systemctl restart sendmail
+systemctl restart dovecot

--- a/mail-symlink-inbox.sh
+++ b/mail-symlink-inbox.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# mail-symlink-inbox.sh
+set -euo pipefail
+
+DEBUG=${DEBUG:-false}
+
+# Symlink /home/user/mail/inbox to /var/spol/mail/inbox
+# This lets dovecot autodetect the ~/mail directory - needed
+# as part of the emergency migration to Obscure's new server.
+# It is going to be hard to get uw-imap back because xinetd won't compile on RHEL 9 derivatives,
+# so everyone is going to use Dovecot going forward.
+#
+# To get Dovecot to auto-detect an inbox it needs to see one of the files
+# listed in Autodetection in 
+# https://doc.dovecot.org/configuration_manual/mail_location/
+cd /home
+ls -d */mail | while read mailuser; do
+    user=$(cut -d/ -f1 <<<"$mailuser")
+    $DEBUG && echo "$user"
+    mail="/home/$user/mail"
+    inboxlink="$mail/inbox"
+    varspool="/var/spool/mail/$user"
+    if [ -d "$mail" ] && [ ! -f "$inboxlink" ]; then
+        $DEBUG && echo ln -s "$varspool" "$inboxlink"
+        ln -s "$varspool" "$inboxlink"
+        chown "$user" "$inboxlink"
+    else
+        $DEBUG && echo "$user did not qualify"
+    fi
+done

--- a/mail-symlink-inbox.sh
+++ b/mail-symlink-inbox.sh
@@ -14,7 +14,7 @@ DEBUG=${DEBUG:-false}
 # listed in Autodetection in 
 # https://doc.dovecot.org/configuration_manual/mail_location/
 cd /home
-ls -d */mail | while read mailuser; do
+find . -maxdepth 2 -type d -name mail | while read mailuser; do
     user=$(cut -d/ -f1 <<<"$mailuser")
     $DEBUG && echo "$user"
     mail="/home/$user/mail"

--- a/mail-symlink-inbox.sh
+++ b/mail-symlink-inbox.sh
@@ -14,7 +14,7 @@ DEBUG=${DEBUG:-false}
 # listed in Autodetection in 
 # https://doc.dovecot.org/configuration_manual/mail_location/
 cd /home
-find . -maxdepth 2 -type d -name mail | while read mailuser; do
+find . -maxdepth 2 -type d -name mail | while read -r mailuser; do
     user=$(cut -d/ -f1 <<<"$mailuser")
     $DEBUG && echo "$user"
     mail="/home/$user/mail"

--- a/tiamat-install.sh
+++ b/tiamat-install.sh
@@ -36,6 +36,7 @@ git
 httpd
 httpd-tools
 krb5-devel
+links
 mariadb
 mariadb-server
 mod_ssl

--- a/tiamat-install.sh
+++ b/tiamat-install.sh
@@ -45,10 +45,16 @@ nagios-plugins-mysql
 nagios-plugins-pgsql
 nagios-plugins-procs
 nagios-plugins-smtp
+nagios-plugins-swap
+nagios-plugins-users
 nmstate
 nrpe
 pam-devel
 php
+php-gd
+php-intl
+php-pecl-zip
+php-pgsql
 postgresql
 postgresql-server
 procmail
@@ -78,10 +84,10 @@ smtps
 
 
 # Install packages
-#shellcheck disable SC2086
+#shellcheck disable=SC2086
 dnf -y install $packages
 
-#shellcheck disable SC2086
+#shellcheck disable=SC2086
 dnf -y install $extra_packages
 
 dnf -y --enablerepo=crb install libtirpc-devel

--- a/tiamat-install.sh
+++ b/tiamat-install.sh
@@ -18,8 +18,10 @@ epel-release
 git
 httpd
 httpd-tools
+krb5-devel
 mod_ssl
 nmstate
+pam-devel
 php
 postgresql
 postgresql-server

--- a/tiamat-install.sh
+++ b/tiamat-install.sh
@@ -27,7 +27,9 @@ packages='
 bind
 bind-chroot
 dovecot
+certbot
 clamav
+cmake
 emacs
 epel-release
 git
@@ -58,10 +60,12 @@ php-pgsql
 postgresql
 postgresql-server
 procmail
+certbot python3-certbot-apache
 sendmail
 sendmail-cf
 spamassassin
 s-nail
+sysstat
 tcsh
 whois
 '
@@ -137,6 +141,8 @@ done
 
 # Adjust selinux
 setsebool -P httpd_enable_homedirs true
+setsebool -P httpd_can_network_connect_db true
+setsebool -P httpd_can_sendmail true
 
 # Relink mail spool files
 "$DIR/mail-symlink-inbox.sh"

--- a/tiamat-install.sh
+++ b/tiamat-install.sh
@@ -44,8 +44,10 @@ smtps
 '
 
 # Install packages
+#shellcheck disable SC2086
 dnf -y install $packages
 
+#shellcheck disable SC2086
 dnf -y install $extra_packages
 
 # Configure network
@@ -74,8 +76,8 @@ sendmail
 spamassassin
 '
 for svc in $services; do
-	systemctl enable $svc
-	systemctl start $svc
+	systemctl enable "$svc"
+	systemctl start "$svc"
 done
 
 # Adjust selinux

--- a/tiamat-install.sh
+++ b/tiamat-install.sh
@@ -13,6 +13,7 @@ packages='
 bind
 bind-chroot
 dovecot
+clamav
 epel-release
 git
 httpd
@@ -24,12 +25,23 @@ postgresql
 postgresql-server
 procmail
 sendmail
+sendmail-cf
+spamassassin
+s-nail
 whois
 '
 
 extra_packages='
 alpine'
 
+firewall_services_allow='
+dns
+http
+https
+smtp
+smtp-submission
+smtps
+'
 
 # Install packages
 dnf -y install $packages
@@ -49,15 +61,17 @@ fi
 
 # Fix up firewall
 systemctl restart firewalld
-firewall-cmd --zone=public --add-service dns
-firewall-cmd --zone=public --add-service http
-firewall-cmd --zone=public --add-service https
+for svc in $firewall_services_allow; do
+    firewall-cmd --zone=public --add-service "$svc"
+done
 firewall-cmd --runtime-to-permanent
 
 # Start services
 services='
 httpd
 named
+sendmail
+spamassassin
 '
 for svc in $services; do
 	systemctl enable $svc

--- a/tiamat-install.sh
+++ b/tiamat-install.sh
@@ -5,6 +5,10 @@
 # failures of August 2022. Installs packages.
 set -euo pipefail
 
+config_network=true
+primary_int=enp89s0
+primary_int=$primary_int
+
 packages='
 bind
 bind-chroot
@@ -13,15 +17,52 @@ epel-release
 git
 httpd
 httpd-tools
+mod_ssl
+nmstate
+php
 postgresql
 postgresql-server
 procmail
 sendmail
+whois
 '
-
-dnf -y install $packages
 
 extra_packages='
 alpine'
 
+
+# Install packages
+dnf -y install $packages
+
 dnf -y install $extra_packages
+
+# Configure network
+
+if "$config_network"; then
+	# Thanks https://www.linuxtechi.com/set-static-ip-address-on-rhel-9/
+	nmcli con modify "$primary_int" ifname $primary_int ipv4.method manual ipv4.addresses 71.163.169.18/24 gw4 71.163.169.1
+	nmcli con modify "$primary_int" ipv4.dns 127.0.0.1
+	nmcli con down "$primary_int"
+	nmcli con up "$primary_int"
+fi
+
+
+# Fix up firewall
+systemctl restart firewalld
+firewall-cmd --zone=public --add-service dns
+firewall-cmd --zone=public --add-service http
+firewall-cmd --zone=public --add-service https
+firewall-cmd --runtime-to-permanent
+
+# Start services
+services='
+httpd
+named
+'
+for svc in $services; do
+	systemctl enable $svc
+	systemctl start $svc
+done
+
+# Adjust selinux
+setsebool -P httpd_enable_homedirs true

--- a/tiamat-install.sh
+++ b/tiamat-install.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# tiamat-install.sh
+#
+# Script used to set up tiamat.obscure.org after the catastropic
+# failures of August 2022. Installs packages.
+set -euo pipefail
+
+packages='
+bind
+bind-chroot
+dovecot
+epel-release
+git
+httpd
+httpd-tools
+postgresql
+postgresql-server
+procmail
+sendmail
+'
+
+dnf -y install $packages
+
+extra_packages='
+alpine'
+
+dnf -y install $extra_packages

--- a/tiamat-install.sh
+++ b/tiamat-install.sh
@@ -28,6 +28,7 @@ bind
 bind-chroot
 dovecot
 clamav
+emacs
 epel-release
 git
 httpd

--- a/tiamat-install.sh
+++ b/tiamat-install.sh
@@ -34,7 +34,15 @@ httpd
 httpd-tools
 krb5-devel
 mod_ssl
+nagios-plugins
+nagios-plugins-disk
+nagios-plugins-load
+nagios-plugins-mysql
+nagios-plugins-pgsql
+nagios-plugins-procs
+nagios-plugins-smtp
 nmstate
+nrpe
 pam-devel
 php
 postgresql

--- a/tiamat-install.sh
+++ b/tiamat-install.sh
@@ -33,7 +33,10 @@ git
 httpd
 httpd-tools
 krb5-devel
+mariadb
+mariadb-server
 mod_ssl
+mutt
 nagios-plugins
 nagios-plugins-disk
 nagios-plugins-load
@@ -52,6 +55,7 @@ sendmail
 sendmail-cf
 spamassassin
 s-nail
+tcsh
 whois
 '
 
@@ -112,7 +116,9 @@ firewall-cmd --runtime-to-permanent
 # Start services
 services='
 httpd
+mariadb
 named
+postgresql
 saslauthd
 sendmail
 spamassassin


### PR DESCRIPTION
On August 18th, the main Obscure server suffered a catastrophic failure. This set of scripts is intended to help recover by installing packages and configuring a system using Rocky Linux 9 so that we can get a replacement server online quickly.